### PR TITLE
Enable YouTube music playback after login

### DIFF
--- a/index.html
+++ b/index.html
@@ -681,6 +681,9 @@ El futuro padre de tus hijos, Adrian Cano Cabello (del pelo).`;
                 document.getElementById('loginSection').style.display = 'none';
                 document.getElementById('letterSection').style.display = 'block';
                 initializeLetter();
+                if (bgPlayer && bgPlayer.playVideo) {
+                    bgPlayer.playVideo();
+                }
                 
                 // Efecto de corazones al entrar
                 setTimeout(() => {


### PR DESCRIPTION
## Summary
- autoplay for the YouTube background playlist could be blocked by browsers
- trigger `bgPlayer.playVideo()` after the user logs in successfully

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684abb279d1c83298ac28d5e75a0e342