### PR TITLE
Fix phrase playback

### DIFF
--- a/index.html
+++ b/index.html
@@ -591,7 +591,6 @@ El futuro padre de tus hijos.`;
         });
 
         // Variables para la reproducción
-        let currentTimeSim = 0;
         const totalPhrases = phraseTimestamps.length;
         let currentAudio = null;
         let isPlaying = false;
@@ -789,19 +788,19 @@ El futuro padre de tus hijos.`;
         function simulateAudioPlayback() {
             const playBtn = document.getElementById('playBtn');
             const pauseBtn = document.getElementById('pauseBtn');
-            
+
             playBtn.style.display = 'none';
             pauseBtn.style.display = 'inline-block';
             isPlaying = true;
             currentPhraseIndex = 0;
-            currentTimeSim = 0;
 
             const phraseElements = document.querySelectorAll('.phrase');
+            phraseElements.forEach(p => p.classList.remove('playing'));
 
             const interval = setInterval(() => {
-                currentTimeSim += 0.1;
+                const current = voiceAudio.currentTime;
 
-                if (currentPhraseIndex + 1 < phraseTimestamps.length && currentTimeSim >= phraseTimestamps[currentPhraseIndex + 1]) {
+                if (currentPhraseIndex + 1 < phraseTimestamps.length && current >= phraseTimestamps[currentPhraseIndex + 1]) {
                     phraseElements[currentPhraseIndex].classList.remove('playing');
                     currentPhraseIndex++;
                 }
@@ -809,10 +808,8 @@ El futuro padre de tus hijos.`;
                 phraseElements[currentPhraseIndex].classList.add('playing');
                 updateProgressBar();
 
-                if (currentPhraseIndex === phraseTimestamps.length - 1 && currentTimeSim >= phraseTimestamps[phraseTimestamps.length - 1] + 3) {
+                if (voiceAudio.paused || voiceAudio.ended) {
                     clearInterval(interval);
-                    phraseElements[currentPhraseIndex].classList.remove('playing');
-                    stopAudio();
                 }
             }, 100);
 
@@ -860,7 +857,9 @@ El futuro padre de tus hijos.`;
             stopAudio();
 
             const timestamp = phraseTimestamps[index];
-            showNotification(`🎵 Aquí saltaría al segundo ${timestamp.toFixed(1)} de tu audio, donde empieza esta frase.\n\nCuando tengas el audio real, esto funcionará automáticamente.`);
+            pauseBackgroundMusic();
+            voiceAudio.currentTime = timestamp;
+            voiceAudio.play().catch(() => {});
 
             simulatePlaybackFromPhrase(index);
         }
@@ -868,14 +867,13 @@ El futuro padre de tus hijos.`;
         function simulatePlaybackFromPhrase(startIndex) {
             const phraseElements = document.querySelectorAll('.phrase');
             currentPhraseIndex = startIndex;
-            currentTimeSim = phraseTimestamps[startIndex];
 
             phraseElements.forEach(p => p.classList.remove('playing'));
 
             const interval = setInterval(() => {
-                currentTimeSim += 0.1;
+                const current = voiceAudio.currentTime;
 
-                if (currentPhraseIndex + 1 < phraseTimestamps.length && currentTimeSim >= phraseTimestamps[currentPhraseIndex + 1]) {
+                if (currentPhraseIndex + 1 < phraseTimestamps.length && current >= phraseTimestamps[currentPhraseIndex + 1]) {
                     phraseElements[currentPhraseIndex].classList.remove('playing');
                     currentPhraseIndex++;
                 }
@@ -883,10 +881,8 @@ El futuro padre de tus hijos.`;
                 phraseElements[currentPhraseIndex].classList.add('playing');
                 updateProgressBar();
 
-                if (currentPhraseIndex === phraseTimestamps.length - 1 && currentTimeSim >= phraseTimestamps[phraseTimestamps.length - 1] + 3) {
+                if (voiceAudio.paused || voiceAudio.ended) {
                     clearInterval(interval);
-                    phraseElements[currentPhraseIndex].classList.remove('playing');
-                    stopAudio();
                 }
             }, 100);
 


### PR DESCRIPTION
## Summary
- enable playing audio from a phrase's timestamp
- update playback tracking to use real audio time

## Testing
- `tidy -errors -q index.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b41c156bc8329a5d753cdfd29fc62